### PR TITLE
Auto setup postgresql database

### DIFF
--- a/src/extensions/postgres/index.js
+++ b/src/extensions/postgres/index.js
@@ -1,0 +1,20 @@
+const {Listr} = require('listr2')
+
+const setupPostgreSQL = () => {
+  return new Listr([
+    {
+      title: 'Connecting to database',
+      task: () => {}, // canConnect(dbConfig)
+    },
+    {
+      title: 'Creating new PostgreSQL user',
+      task: () => {}, // createUser(dbConfig)
+    },
+    {
+      title: 'Granting new user permissions',
+      task: () => {}, // grantPermissions(dbConfig)
+    },
+  ])
+}
+
+module.exports = setupPostgreSQL


### PR DESCRIPTION
This PR will add the option to auto setup the database.

Auto setup option can be disabled by passing `--no-setup` flag

**Usage**

```bash
$ logchimp install --no-setup
```