### PR TITLE
tests: remove logchimp configuration beforeEach test

### DIFF
--- a/tests/command/config-generate.spec.js
+++ b/tests/command/config-generate.spec.js
@@ -7,13 +7,13 @@ const CLI_PATH = path.resolve(__dirname, '..', '..', 'bin', 'run')
 const runCommand = (args, options) => execa(CLI_PATH, args, options)
 
 describe('config:generate command', () => {
-  describe('generate config', () => {
-    beforeEach(async () => {
-      // fail-safe: delete any existing logchimp config at root directory
-      const currentDirectory = await process.cwd()
-      await fs.removeSync(`${currentDirectory}/logchimp.config.json`)
-    })
+  beforeEach(async () => {
+    // fail-safe: delete any existing logchimp config at root directory
+    const currentDirectory = await process.cwd()
+    await fs.removeSync(`${currentDirectory}/logchimp.config.json`)
+  })
 
+  describe('generate config', () => {
     it('with default values', async () => {
       const command = await runCommand(['config:generate'])
 
@@ -66,6 +66,7 @@ describe('config:generate command', () => {
     it('with --force flag', async () => {
       // create config file with defaults
       await runCommand(['config:generate'])
+
       const command = await runCommand(['config:generate', '--force'])
 
       expect(command.stderr).toContain('Warning: This will overwrite the exisiting configuration file, if present.')
@@ -81,6 +82,9 @@ describe('config:generate command', () => {
   })
 
   it('config already exists', async () => {
+    // generate config file
+    await runCommand(['config:generate'])
+
     const command = await runCommand(['config:generate'])
 
     expect(command.stdout).toBe('Logchimp configuration file already exists.')

--- a/tests/command/config-get.spec.js
+++ b/tests/command/config-get.spec.js
@@ -6,18 +6,22 @@ const CLI_PATH = path.resolve(__dirname, '..', '..', 'bin', 'run')
 const runCommand = (args, options) => execa(CLI_PATH, args, options)
 
 describe('config:get command', () => {
-  it('config file missing error', async () => {
+  beforeEach(async () => {
     // fail-safe: delete any existing logchimp config at root directory
     const currentDirectory = await process.cwd()
     await fs.removeSync(`${currentDirectory}/logchimp.config.json`)
+  })
 
+  it('config file missing error', async () => {
     const command = await runCommand(['config:get'])
+
     expect(command.stderr).toContain('Warning: Logchimp configuration file doesn\'t exist.')
   })
 
   it('--key flag is missing', async () => {
     // generate config file
     await runCommand(['config:generate'])
+
     const command = await runCommand(['config:get'])
 
     expect(command.stdout).toContain(
@@ -26,6 +30,9 @@ describe('config:get command', () => {
   })
 
   it('get \'database.port\' value', async () => {
+    // generate config file
+    await runCommand(['config:generate'])
+
     const command = await runCommand(['config:get', '-k=database.port'])
 
     expect(command.stdout).toBe('5432')

--- a/tests/command/config-set.spec.js
+++ b/tests/command/config-set.spec.js
@@ -6,12 +6,15 @@ const CLI_PATH = path.resolve(__dirname, '..', '..', 'bin', 'run')
 const runCommand = (args, options) => execa(CLI_PATH, args, options)
 
 describe('config:set command', () => {
-  it('config file missing error', async () => {
-    // delete any existing logchimp config at root directory
+  beforeEach(async () => {
+    // fail-safe: delete any existing logchimp config at root directory
     const currentDirectory = await process.cwd()
     await fs.removeSync(`${currentDirectory}/logchimp.config.json`)
+  })
 
+  it('config file missing error', async () => {
     const command = await runCommand(['config:set'])
+
     expect(command.stderr).toContain(
       "Warning: Logchimp configuration file doesn't exist.",
     )
@@ -20,6 +23,7 @@ describe('config:set command', () => {
   it('--key & --value flag is missing', async () => {
     // generate config file
     await runCommand(['config:generate'])
+
     const command = await runCommand(['config:set'])
 
     expect(command.stderr).toContain(
@@ -28,6 +32,9 @@ describe('config:set command', () => {
   })
 
   it('update \'secretkey\' value', async () => {
+    // generate config file
+    await runCommand(['config:generate'])
+
     await runCommand(['config:set', '-k=secretkey', '-v=mySecretKey'])
 
     const currentDirectory = await process.cwd()


### PR DESCRIPTION
Running a fail safe function `beforeEach` function to remove any existing `logchimp.config.json` file before running unit test.