### PR TITLE
Fix the structure of the configuration file generated by config:generate

### DIFF
--- a/src/commands/config/generate.js
+++ b/src/commands/config/generate.js
@@ -42,11 +42,14 @@ class ConfigGenerateCommand extends Command {
     }
 
     const generateConfig = {
-      local: flags.local,
-      port: flags.port,
-      secretkey: flags.secretkey ? flags.secretkey : generatePassword(),
+      server: {
+        local: flags.local,
+        port: flags.port,
+        secretkey: flags.secretkey ? flags.secretkey : generatePassword(),
+      },
       database: {
         host: flags.dbhost,
+        name: flags.dbname,
         port: flags.dbport,
         user: flags.dbuser,
         password: flags.dbpass,

--- a/src/utils/ask-questions.js
+++ b/src/utils/ask-questions.js
@@ -12,7 +12,7 @@ const askQuestions = async () => {
     // server
     {
       type: 'confirm',
-      name: 'local',
+      name: 'server.local',
       message: 'Run LogChimp for local development/testing',
       choices: ['false', 'true'],
       default: false,

--- a/tests/command/config-generate.spec.js
+++ b/tests/command/config-generate.spec.js
@@ -24,6 +24,17 @@ describe('config:generate command', () => {
       const config = fs.readJsonSync(`${currentDirectory}/logchimp.config.json`)
       const isConfigEmpty = _.isEmpty(config)
       expect(isConfigEmpty).toBe(false)
+
+      // server
+      expect(config.server.local).toBe(false)
+      expect(config.server.port).toBe(3000)
+
+      // database
+      expect(config.database.port).toBe(5432)
+      expect(config.database.ssl).toBe(true)
+
+      // mail
+      expect(config.mail.port).toBe(587)
     })
 
     it('with flags', async () => {

--- a/tests/command/config-generate.spec.js
+++ b/tests/command/config-generate.spec.js
@@ -51,15 +51,15 @@ describe('config:generate command', () => {
       const config = fs.readJsonSync(`${currentDirectory}/logchimp.config.json`)
 
       // server
-      expect(config.local).toBe(false)
-      expect(config.port).toBe(80)
-      expect(config.secretkey).toBe('mySecretKey')
+      expect(config.server.local).toBe(false)
+      expect(config.server.port).toBe(80)
+      expect(config.server.secretkey).toBe('mySecretKey')
       // database
       expect(config.database.host).toBe('postgres-db.logchimp.codecarrot.net')
+      expect(config.database.name).toBe('pg_db')
       expect(config.database.port).toBe(51000)
       expect(config.database.user).toBe('pg_db_user')
       expect(config.database.password).toBe('myDatabasePassword')
-      expect(config.database.ssl).toBe(false)
       expect(config.database.ssl).toBe(false)
 
       // mail

--- a/tests/command/config-set.spec.js
+++ b/tests/command/config-set.spec.js
@@ -31,10 +31,10 @@ describe('config:set command', () => {
     // generate config file
     await runCommand(['config:generate'])
 
-    await runCommand(['config:set', '-k=secretkey', '-v=mySecretKey'])
+    await runCommand(['config:set', '-k=server.secretkey', '-v=mySecretKey'])
 
     const currentDirectory = await process.cwd()
     const config = fs.readJsonSync(`${currentDirectory}/logchimp.config.json`)
-    expect(config.secretkey).toBe('mySecretKey')
+    expect(config.server.secretkey).toBe('mySecretKey')
   })
 })


### PR DESCRIPTION
This pull request fixes the config generated by the `logchimp config:generate` command
* Fix the location of the created server configuration variables:
  - changes `config.port` to `config.server.port`
  - changes `config.secretkey` to `config.server.secretkey`
  - changes `config.local` to `config.server.local`
* Add the database name to the generated configuration file
* Fix the location of local when interactive flag is used